### PR TITLE
Start of some Rails/Node.js tooling

### DIFF
--- a/lib/generators/nodeify/install/install_generator.rb
+++ b/lib/generators/nodeify/install/install_generator.rb
@@ -1,0 +1,27 @@
+require 'rails/generators/base'
+
+module Nodeify
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      desc <<DESC
+Description:
+  Generates package.json file for npm
+DESC
+
+      def install_package_json
+        vendor "package.json" do
+          <<JSON
+{
+  "name": "nodeify",
+  "version": "0.1.0",
+  "dependencies": {
+    "browserify": "1.5.0"
+  }
+}
+JSON
+        end
+      end
+
+    end
+  end
+end

--- a/lib/generators/nodeify/install/install_generator.rb
+++ b/lib/generators/nodeify/install/install_generator.rb
@@ -22,6 +22,11 @@ JSON
         end
       end
 
+      def install_npm_modules
+        rake "npm:install"
+        append_to_file ".gitignore", "vendor/node_modules"
+      end
+
     end
   end
 end

--- a/lib/nodeify/rails.rb
+++ b/lib/nodeify/rails.rb
@@ -11,5 +11,9 @@ module Nodeify
       app.assets.unregister_preprocessor 'application/javascript', Sprockets::DirectiveProcessor
       app.assets.register_bundle_processor 'application/javascript', Nodeify::JavaScript
     end
+
+    rake_tasks do
+      load 'nodeify/tasks/npm.rake'
+    end
   end
 end

--- a/lib/nodeify/tasks/npm.rake
+++ b/lib/nodeify/tasks/npm.rake
@@ -1,0 +1,7 @@
+desc "Install npm packages specified in vendor/package.json"
+namespace :npm do
+  task :install do
+    `(cd vendor/ && npm install)`
+  end
+end
+


### PR DESCRIPTION
I added a rake task to install npm modules and a generator for the package.json that:

1) Adds a package.json to vendor/
2) Runs the aforementioned rake task and .gitignores node_modules

Currently the default package.json only includes browserify; we can be opinionated here and give a great default testing setup, but this should at least get us started.
